### PR TITLE
Respect clip mask of frames

### DIFF
--- a/src/penai/svg.py
+++ b/src/penai/svg.py
@@ -643,6 +643,7 @@ class PenpotPageSVG(SVG):
         self,
         web_driver: WebDriver | RegisteredWebDriver,
         selected_shape_elements: Iterable[PenpotShapeElement] | None = None,
+        respect_clip_masks: bool = True,
         show_progress: bool = True,
     ) -> None:
         """Retrieve the default view boxes for all shapes in the SVG and set them on the shapes.
@@ -675,7 +676,8 @@ class PenpotPageSVG(SVG):
             for shape_el in selected_shape_elements:
                 # Frames will typically have a clip-path that defines the clip mask.
                 if (
-                    shape_el.type is PenpotShapeType.FRAME
+                    respect_clip_masks
+                    and shape_el.type is PenpotShapeType.FRAME
                     and (clip_rect := shape_el.get_clip_rect()) is not None
                 ):
                     shape_bbox = clip_rect


### PR DESCRIPTION
Frame shapes in Penpot can have content clipping enabled in which case their corresponding main `<g>`-element will have the `clip-path` attribute set which will reference a clip mask defined in the `<defs>`-section of that shape.

This PR changes `PenpotShapeElement`'s `get_default_view_box` method in such a way, that the clip rect is returned as default view box if the clip rect is set for a frame shape.

Examples on how this affects the rendering of frames with overflowing content in the "Interactive Music App"-design:

![home-without-clipping](https://github.com/penpot/penai/assets/1430243/ee0bdab3-76e4-467c-abb2-e25e85bbe69b) ![home-with-clipping](https://github.com/penpot/penai/assets/1430243/e8b6e0af-63ed-46fe-bfb1-7daee1d8952e)

![playlist-without-clipping](https://github.com/penpot/penai/assets/1430243/a2cd666a-9429-43b5-9e49-99b3faeaa3fe) ![playlist-with-clipping](https://github.com/penpot/penai/assets/1430243/b4b6932f-a6ac-4390-b6f2-00ce7faab69d)

Note: this PR merged into `feature/first-steps-design-to-text`.