### PR TITLE
Refactor Penpot shape creation and relations logic

### DIFF
--- a/test/penai/test_registries.py
+++ b/test/penai/test_registries.py
@@ -10,7 +10,6 @@ projects_to_test = [
 
 
 class TestPenpotProjectRegistry:
-
     @staticmethod
     @pytest.mark.parametrize("project", projects_to_test)
     def test_can_be_loaded(project: SavedPenpotProject) -> None:

--- a/test/penai/test_renderers.py
+++ b/test/penai/test_renderers.py
@@ -49,7 +49,6 @@ class TestSVGRenderers:
         example_png_path: Path,
         log_dir: Path,
     ) -> None:
-
         renderer = ResvgRenderer()
 
         _test_svg_renderer(renderer, example_svg_path, example_png_path, log_dir)

--- a/test/penai/test_svg.py
+++ b/test/penai/test_svg.py
@@ -20,19 +20,19 @@ class TestPenpotShape:
 
     @staticmethod
     def test_parent_child_shapes_basics(penpot_page_svg: PenpotPageSVG) -> None:
-        roots = penpot_page_svg.get_shape_elements_at_depth(0)
-        leaves_subset = penpot_page_svg.get_shape_elements_at_depth(
-            penpot_page_svg.max_shape_depth
-        )
+        roots = list(penpot_page_svg.iter_shape_elements_at_depth(0))
+        leaves_subset = list(penpot_page_svg.iter_shape_elements_at_depth(penpot_page_svg.max_shape_depth))
         for root in roots:
             assert root.get_parent_shape() is None
             for child in root.get_direct_children_shapes():
                 assert child.get_parent_shape() == root
         for leaf in leaves_subset:
-            assert not leaf.get_all_children_shapes()
+            assert not list(leaf.iter_all_children_shapes())
             assert not leaf.get_direct_children_shapes()
             assert leaf.get_parent_shape() is not None
-            assert leaf in leaf.get_parent_shape().get_all_children_shapes()
+
+            if (parent_shape := leaf.get_parent_shape()):
+                assert leaf in list(parent_shape.iter_all_children_shapes())
 
 
 class TestPenpotPageSVG:
@@ -41,7 +41,7 @@ class TestPenpotPageSVG:
         penpot_page_svg: PenpotPageSVG,
         chrom_web_driver: WebDriver,
     ) -> None:
-        shapes = penpot_page_svg.penpot_shape_elements
+        shapes = list(penpot_page_svg.iter_all_shape_elements())
 
         # Should be None before deriving
         for shape in shapes:


### PR DESCRIPTION
The current shape relations logic in the `svg` module might lead to duplicate shape elements.

The `PenpotPageSVG` class searches for all Penpot shapes recursively in the following line, which should be assumed as the sole creation point of `PenpotShapeElement` instances:

https://github.com/penpot/penai/blob/51d61f89a803b00c0aec7a88fcc15b836f732620/src/penai/svg.py#L420

However, the `PenpotShapeElement.get_all_children_shapes()` and `get_parent_shape()` method will create new instances of Penpot shapes that are already present in the parent `PenpotPageSVG` object which can be seen as duplicate objects of the underlying Penpot shape.

This leads to highly unintuitive behavior. For instance, if the two aforementioned methods are used to navigate within the parents and children of a `PenpotShapeElement`, the relatives will be instantiated on the fly and don't contain the view box information anymore, which might have been derived for the whole page before.

This PR changes the fundamental shape creation and relations logic in the following way:
- `PenpotPageSVG` now only derives the top-level elements. The responsibility to find and manage children below that level subsequently is in `PenpotShapeElement`'s responsibility.
- `PenpotShapeElement`s derive or set their own children (and possibly parent) in the constructor and store them for their lifetime. No new `PenpotShapeElement` objects are created in any method.
- Many getter functions have been turned into generators to reflect the nature of these more indirect relations. I'm personally a friend of using generators for such cases but I'm open to turn them into list-returning getters if you, @MischaPanch, find this more convenient.